### PR TITLE
create symbols & fallback for unexpected type

### DIFF
--- a/svg.import.js
+++ b/svg.import.js
@@ -89,6 +89,10 @@
         case 'defs':
           convertNodes(child.childNodes, context.defs(), level + 1, store, block)
         break
+        case 'symbol':
+            element = context.symbol()
+            convertNodes(child.childNodes, context.symbol(), level + 1, store, block)
+        break
         case 'use':
           element = context.use()
         break
@@ -126,6 +130,7 @@
           break
         default:
           console.log('SVG Import got unexpected type ' + type, child)
+          convertNodes(child.childNodes, context.nested(), level + 1, store, block)
         break
       }
       


### PR DESCRIPTION
- the 'symbol' case is pretty straightforward
- I think that the 'unexpected type' case shouldn't be a reason to stop building the tree, in this case, an inkscape-generated sodipodi:namedview element (which was the root of my svg) was irrelevant but stopping everything from working.
